### PR TITLE
Fixed a naming conflict

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -145,18 +145,18 @@ public unsafe class Mod : ModBase
         {
             try
             {
-                var config = JsonSerializer.Deserialize<Config>(File.ReadAllText(batonConfigFile));
-                if (config == null)
+                var jconfig = JsonSerializer.Deserialize<Config>(File.ReadAllText(batonConfigFile));
+                if (jconfig == null)
                 {
                     return;
                 }
 
-                _config.HP_Level_1 = _config.HP_Level_1;
-                _config.HP_Level_2 = _config.HP_Level_2;
-                _config.HP_Level_3 = _config.HP_Level_3;
-                _config.SP_Level_1 = _config.SP_Level_1;
-                _config.SP_Level_2 = _config.SP_Level_2;
-                _config.SP_Level_3 = _config.SP_Level_3;
+                _config.HP_Level_1 = jconfig.HP_Level_1;
+                _config.HP_Level_2 = jconfig.HP_Level_2;
+                _config.HP_Level_3 = jconfig.HP_Level_3;
+                _config.SP_Level_1 = jconfig.SP_Level_1;
+                _config.SP_Level_2 = jconfig.SP_Level_2;
+                _config.SP_Level_3 = jconfig.SP_Level_3;
                 ApplyHpSettings();
 
                 _configLoaded = true;


### PR DESCRIPTION
Fixed a naming conflict with the config variable that holds the deserialized data of the .json file by renaming it from config to jconfig. This will prevent the IDE or anyone from confusing between the mod config and the .json file config.

I tested it before the fix and it did not work, but after the fix it worked perfectly. It may work for some depending on if the IDE was able to tell them apart.